### PR TITLE
Use parameter files for Azure deployment

### DIFF
--- a/.github/workflows/deploy_infra.yml
+++ b/.github/workflows/deploy_infra.yml
@@ -19,4 +19,4 @@ jobs:
 
       - name: Deploy Bicep files
         run: |
-          az deployment group create --resource-group ${{ secrets.AZURE_RESOURCE_GROUP }} --template-file ./infra/main.bicep --parameters appServiceName=${{ secrets.APP_SERVICE_NAME }} storageAccountName=${{ secrets.STORAGE_ACCOUNT_NAME }}
+          az deployment group create --resource-group ${{ secrets.AZURE_RESOURCE_GROUP }} --template-file ./infra/main.bicep --parameters @infra/main.parameters.json

--- a/infra/main.parameters.json
+++ b/infra/main.parameters.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "appServiceName": {
+      "value": "your-app-service-name"
+    },
+    "storageAccountName": {
+      "value": "your-storage-account-name"
+    },
+    "location": {
+      "value": "your-location"
+    }
+  }
+}


### PR DESCRIPTION
Related to #14

Implements the use of parameter files for Azure infrastructure deployment to enable staging environments.

- **Adds a parameter file**: Creates `infra/main.parameters.json` with parameters for `appServiceName`, `storageAccountName`, and `location` to facilitate environment-specific deployments.
- **Updates deployment command**: Modifies `.github/workflows/deploy_infra.yml` to use the newly added parameter file `@infra/main.parameters.json` instead of inline parameters, streamlining the deployment process.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/akbast/copilot-workspace/issues/14?shareId=9fedb7d3-d461-4440-b55e-1371c5194e6c).